### PR TITLE
feat: provide wrapper to add plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,15 @@ npm i vitepress-plugin-mermaid -s
 
 ## Setup it up
 
-Add plugin
+Add wrapper
 
 ```js
-//vite.config.ts
-import { defineConfig } from "vite";
-import { MermaidPlugin } from "vitepress-plugin-mermaid";
+// .vitepress/config.js
+import { withMermaid } from "vitepress-plugin-mermaid";
 
-export default defineConfig({
-  plugins: [MermaidPlugin()],
+export default withMermaid({
+  // your existing vitepress config...
 });
-```
-
-Add markdown
-
-```js
-//.vitepress/config.js
-import  { MermaidMarkdown } from "vitepress-plugin-mermaid";
-
-module.exports = {
-  ...
-  markdown: {
-    config: MermaidMarkdown,
-  },
-  ...
-}
 ```
 
 Use in any Markdown file

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,3 @@
-import { defineConfig } from "vitepress";
 import { withMermaid } from "../../src";
 import { version } from "../../package.json";
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,33 +1,36 @@
+import { defineConfig } from "vitepress";
 import { withMermaid } from "../../src";
 import { version } from "../../package.json";
 
-export default withMermaid({
-  lang: "en-US",
-  title: "VitePress Plugin Mermaid",
-  description: "Mermaid support for vitepress",
-  base: "/vitepress-plugin-mermaid/",
-  lastUpdated: true,
+export default withMermaid(
+  defineConfig({
+    lang: "en-US",
+    title: "VitePress Plugin Mermaid",
+    description: "Mermaid support for vitepress",
+    base: "/vitepress-plugin-mermaid/",
+    lastUpdated: true,
 
-  themeConfig: {
-    nav: nav(),
+    themeConfig: {
+      nav: nav(),
 
-    sidebar: {
-      "/guide/": sidebarGuide(),
-    },
-
-    socialLinks: [
-      {
-        icon: "github",
-        link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
+      sidebar: {
+        "/guide/": sidebarGuide(),
       },
-    ],
 
-    footer: {
-      message: "Released under the MIT License.",
-      copyright: "Copyright © 2021-present Emerson Bottero",
+      socialLinks: [
+        {
+          icon: "github",
+          link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
+        },
+      ],
+
+      footer: {
+        message: "Released under the MIT License.",
+        copyright: "Copyright © 2021-present Emerson Bottero",
+      },
     },
-  },
-});
+  })
+);
 
 function nav() {
   return [

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -2,35 +2,33 @@ import { defineConfig } from "vitepress";
 import { withMermaid } from "../../src";
 import { version } from "../../package.json";
 
-export default withMermaid(
-  defineConfig({
-    lang: "en-US",
-    title: "VitePress Plugin Mermaid",
-    description: "Mermaid support for vitepress",
-    base: "/vitepress-plugin-mermaid/",
-    lastUpdated: true,
+export default withMermaid({
+  lang: "en-US",
+  title: "VitePress Plugin Mermaid",
+  description: "Mermaid support for vitepress",
+  base: "/vitepress-plugin-mermaid/",
+  lastUpdated: true,
 
-    themeConfig: {
-      nav: nav(),
+  themeConfig: {
+    nav: nav(),
 
-      sidebar: {
-        "/guide/": sidebarGuide(),
-      },
-
-      socialLinks: [
-        {
-          icon: "github",
-          link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
-        },
-      ],
-
-      footer: {
-        message: "Released under the MIT License.",
-        copyright: "Copyright © 2021-present Emerson Bottero",
-      },
+    sidebar: {
+      "/guide/": sidebarGuide(),
     },
-  })
-);
+
+    socialLinks: [
+      {
+        icon: "github",
+        link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
+      },
+    ],
+
+    footer: {
+      message: "Released under the MIT License.",
+      copyright: "Copyright © 2021-present Emerson Bottero",
+    },
+  },
+});
 
 function nav() {
   return [

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,37 +1,36 @@
 import { defineConfig } from "vitepress";
-import { MermaidMarkdown } from "../../src/mermaid-markdown";
+import { withMermaid } from "../../src";
 import { version } from "../../package.json";
 
-export default defineConfig({
-  lang: "en-US",
-  title: "VitePress Plugin Mermaid",
-  description: "Mermaid support for vitepress",
-  base: "/vitepress-plugin-mermaid/",
-  lastUpdated: true,
-  markdown: {
-    config: MermaidMarkdown,
-  },
+export default withMermaid(
+  defineConfig({
+    lang: "en-US",
+    title: "VitePress Plugin Mermaid",
+    description: "Mermaid support for vitepress",
+    base: "/vitepress-plugin-mermaid/",
+    lastUpdated: true,
 
-  themeConfig: {
-    nav: nav(),
+    themeConfig: {
+      nav: nav(),
 
-    sidebar: {
-      "/guide/": sidebarGuide(),
-    },
-
-    socialLinks: [
-      {
-        icon: "github",
-        link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
+      sidebar: {
+        "/guide/": sidebarGuide(),
       },
-    ],
 
-    footer: {
-      message: "Released under the MIT License.",
-      copyright: "Copyright © 2021-present Emerson Bottero",
+      socialLinks: [
+        {
+          icon: "github",
+          link: "https://github.com/emersonbottero/vitepress-plugin-mermaid",
+        },
+      ],
+
+      footer: {
+        message: "Released under the MIT License.",
+        copyright: "Copyright © 2021-present Emerson Bottero",
+      },
     },
-  },
-});
+  })
+);
 
 function nav() {
   return [

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -22,15 +22,18 @@ Add wrapper
 
 ```js
 // .vitepress/config.js
+import { defineConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
-export default withMermaid({
-  // your existing vitepress config...
-  // optionally, you can pass MermaidConfig
-  mermaid: {
-    // refer https://mermaid-js.github.io/mermaid/#/Setup for options
-  },
-});
+export default withMermaid(
+  defineConfig({
+    // your existing vitepress config...
+    // optionally, you can pass MermaidConfig
+    mermaid: {
+      // refer https://mermaid-js.github.io/mermaid/#/Setup for options
+    },
+  })
+);
 ```
 
 Use in any Markdown file

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -18,31 +18,19 @@ npm i vitepress-plugin-mermaid -s
 
 ## Setup it up
 
-Add plugin, it accepts an [MermaidConfig](https://mermaid-js.github.io/mermaid/#/Setup) as parameter.
+Add wrapper
 
 ```js
-//vite.config.ts
-import { defineConfig } from "vite";
-import { MermaidPlugin } from "vitepress-plugin-mermaid";
+// .vitepress/config.js
+import { withMermaid } from "vitepress-plugin-mermaid";
 
-export default defineConfig({
-  plugins: [MermaidPlugin()],
-});
-```
-
-Add markdown
-
-```js
-//.vitepress/config.js
-import { MermaidMarkdown } from "vitepress-plugin-mermaid";
-
-module.exports = {
-  ...
-  markdown: {
-    config: MermaidMarkdown,
+export default withMermaid({
+  // your existing vitepress config...
+  // optionally, you can pass MermaidConfig
+  mermaid: {
+    // refer https://mermaid-js.github.io/mermaid/#/Setup for options
   },
-  ...
-}
+});
 ```
 
 Use in any Markdown file

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -1,8 +1,6 @@
 import { defineConfig } from "vite";
-import { MermaidPlugin } from "../";
 
 export default defineConfig({
-  plugins: [MermaidPlugin()],
   resolve: {
     alias: {
       "vitepress-plugin-mermaid/Mermaid.vue": "../../../../../dist/Mermaid.vue",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitepress-plugin-mermaid",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitepress-plugin-mermaid",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/mermaid": "^8.2.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,17 @@
-import type { DefaultTheme, UserConfig } from "vitepress";
+import { type UserConfig } from "vitepress";
 import { MermaidMarkdown } from "./mermaid-markdown";
 import { MermaidPlugin, type MermaidConfig } from "./mermaid-plugin";
 
 export { MermaidMarkdown } from "./mermaid-markdown";
 export { MermaidPlugin } from "./mermaid-plugin";
 
-export interface VitePressMermaidOptions<ThemeConfig = any>
-  extends UserConfig<ThemeConfig> {
-  mermaid?: Partial<MermaidConfig>;
+declare module "vitepress" {
+  interface UserConfig {
+    mermaid?: MermaidConfig;
+  }
 }
 
-export const withMermaid = (
-  config: VitePressMermaidOptions<DefaultTheme.Config>
-) => {
+export const withMermaid = (config: UserConfig) => {
   if (!config.markdown) config.markdown = {};
   const markdownConfigOriginal = config.markdown.config || (() => {});
   config.markdown.config = (...args) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,21 @@
-import { Plugin } from "vite";
+import { type UserConfig } from "vitepress";
+import { MermaidMarkdown } from "./mermaid-markdown";
+import { MermaidPlugin } from "./mermaid-plugin";
+
 export { MermaidMarkdown } from "./mermaid-markdown";
-//TODO: use this when mermaid 9.2 is published!
-//import { MermaidConfig } from "mermaid/dist/config.type";
+export { MermaidPlugin } from "./mermaid-plugin";
 
-interface MermaidConfig {}
+export const withMermaid = (config: UserConfig) => {
+  if (!config.markdown) config.markdown = {};
+  const markdownConfigOriginal = config.markdown.config || (() => {});
+  config.markdown.config = (...args) => {
+    MermaidMarkdown(...args);
+    markdownConfigOriginal(...args);
+  };
 
-const DEFAULT_OPTIONS: MermaidConfig = {
-  //We set loose as default here because is needed to load images
-  securityLevel: "loose",
-  startOnLoad: false,
+  if (!config.vite) config.vite = {};
+  if (!config.vite.plugins) config.vite.plugins = [];
+  config.vite.plugins.push(MermaidPlugin());
+
+  return config;
 };
-
-export function MermaidPlugin(inlineOptions?: Partial<MermaidConfig>): Plugin {
-  // eslint-disable-next-line no-unused-vars
-  const options = {
-    ...DEFAULT_OPTIONS,
-    ...inlineOptions,
-  };
-
-  const virtualModuleId = "virtual:mermaid-config";
-  const resolvedVirtualModuleId = "\0" + virtualModuleId;
-
-  return {
-    name: "vite-plugin-mermaid",
-    enforce: "post",
-
-    transform(src, id) {
-      //Register Mermaid component in vue instance creation
-      if (id.includes("vitepress/dist/client/app/index.js")) {
-        src =
-          "\nimport Mermaid from 'vitepress-plugin-mermaid/Mermaid.vue';\n" +
-          src;
-        src = src.replace(
-          "// install global components",
-          "// install global components\n\t\tapp.component('Mermaid', Mermaid);\n"
-        );
-        return {
-          code: src,
-          map: null, // provide source map if available
-        };
-      }
-    },
-
-    async resolveId(id) {
-      if (id === virtualModuleId) {
-        return resolvedVirtualModuleId;
-      }
-    },
-    async load(this, id) {
-      if (id === resolvedVirtualModuleId) {
-        return `export default ${JSON.stringify(options)};`;
-      }
-    },
-  };
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
-import { type UserConfig } from "vitepress";
+import type { DefaultTheme, UserConfig } from "vitepress";
 import { MermaidMarkdown } from "./mermaid-markdown";
-import { MermaidPlugin } from "./mermaid-plugin";
+import { MermaidPlugin, type MermaidConfig } from "./mermaid-plugin";
 
 export { MermaidMarkdown } from "./mermaid-markdown";
 export { MermaidPlugin } from "./mermaid-plugin";
 
-export const withMermaid = (config: UserConfig) => {
+export interface VitePressMermaidOptions<ThemeConfig = any>
+  extends UserConfig<ThemeConfig> {
+  mermaid?: Partial<MermaidConfig>;
+}
+
+export const withMermaid = (
+  config: VitePressMermaidOptions<DefaultTheme.Config>
+) => {
   if (!config.markdown) config.markdown = {};
   const markdownConfigOriginal = config.markdown.config || (() => {});
   config.markdown.config = (...args) => {
@@ -15,7 +22,7 @@ export const withMermaid = (config: UserConfig) => {
 
   if (!config.vite) config.vite = {};
   if (!config.vite.plugins) config.vite.plugins = [];
-  config.vite.plugins.push(MermaidPlugin());
+  config.vite.plugins.push(MermaidPlugin(config.mermaid));
 
   return config;
 };

--- a/src/mermaid-plugin.ts
+++ b/src/mermaid-plugin.ts
@@ -2,7 +2,9 @@ import { Plugin } from "vite";
 //TODO: use this when mermaid 9.2 is published!
 //import { MermaidConfig } from "mermaid/dist/config.type";
 
-interface MermaidConfig {}
+export interface MermaidConfig {
+  [x: string]: any;
+}
 
 const DEFAULT_OPTIONS: MermaidConfig = {
   //We set loose as default here because is needed to load images

--- a/src/mermaid-plugin.ts
+++ b/src/mermaid-plugin.ts
@@ -1,0 +1,55 @@
+import { Plugin } from "vite";
+//TODO: use this when mermaid 9.2 is published!
+//import { MermaidConfig } from "mermaid/dist/config.type";
+
+interface MermaidConfig {}
+
+const DEFAULT_OPTIONS: MermaidConfig = {
+  //We set loose as default here because is needed to load images
+  securityLevel: "loose",
+  startOnLoad: false,
+};
+
+export function MermaidPlugin(inlineOptions?: Partial<MermaidConfig>): Plugin {
+  // eslint-disable-next-line no-unused-vars
+  const options = {
+    ...DEFAULT_OPTIONS,
+    ...inlineOptions,
+  };
+
+  const virtualModuleId = "virtual:mermaid-config";
+  const resolvedVirtualModuleId = "\0" + virtualModuleId;
+
+  return {
+    name: "vite-plugin-mermaid",
+    enforce: "post",
+
+    transform(src, id) {
+      //Register Mermaid component in vue instance creation
+      if (id.includes("vitepress/dist/client/app/index.js")) {
+        src =
+          "\nimport Mermaid from 'vitepress-plugin-mermaid/Mermaid.vue';\n" +
+          src;
+        src = src.replace(
+          "// install global components",
+          "// install global components\n\t\tapp.component('Mermaid', Mermaid);\n"
+        );
+        return {
+          code: src,
+          map: null, // provide source map if available
+        };
+      }
+    },
+
+    async resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+    async load(this, id) {
+      if (id === resolvedVirtualModuleId) {
+        return `export default ${JSON.stringify(options)};`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
It simplifies stuff. Users just need to import `withMermaid` in their VitePress config and wrap their config with it. It's similar to what we are doing in other plugins (https://github.com/userquin/vite-pwa-vitepress-integration for example). The changes are backward compatible - `MermaidMarkdown` and `MermaidPlugin` are still exported.