### PR TITLE
docs: ask users to install mermaid too

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and a [complex example 😎](https://emersonbottero.github.io/vitepress-plugin-m
 ## Install
 
 ```bash
-npm i vitepress-plugin-mermaid -s
+npm i vitepress-plugin-mermaid mermaid -D
 ```
 
 ## Setup it up

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,7 +13,7 @@ You can still highlight mermaid code with mmd as language
 ## Install
 
 ```bash
-npm i vitepress-plugin-mermaid -s
+npm i vitepress-plugin-mermaid mermaid -D
 ```
 
 ## Setup it up

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
   },
   "homepage": "https://github.com/emersonbottero/vitepress-plugin-mermaid#readme",
   "peerDependencies": {
-    "mermaid": "^8.0.0 || ^9.0.0",
-    "vite-plugin-md": "^0.20.4",
-    "vitepress": "^0.21.6 || ^1.0.0 || ^1.0.0-alpha"
+    "mermaid": "^8.0.0 || ^9.0.0"
   },
   "devDependencies": {
     "@types/mermaid": "^8.2.9",


### PR DESCRIPTION
fixes #19 

npm (>=3 <7) does not install peer deps by default. Strict package managers like pnpm and yarn v2+ also don't. It's better to make users directly install mermaid too to avoid confusion.

Regarding that virtual module thing mentioned in the linked issue, I've fixed that in VitePress, it'll be there in the next version.