### PR TITLE
fix: can't write alias properly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,13 +39,25 @@ export const withMermaid = (config: UserConfig) => {
   if (!config.vite.resolve) config.vite.resolve = {};
   if (!config.vite.resolve.alias) config.vite.resolve.alias = {};
 
-  config.vite.resolve.alias = {
+  config.vite.resolve.alias = [
     ...config.vite.resolve.alias,
-    "dayjs/plugin/advancedFormat.js": "dayjs/esm/plugin/advancedFormat",
-    "dayjs/plugin/customParseFormat.js": "dayjs/esm/plugin/customParseFormat",
-    "dayjs/plugin/isoWeek.js": "dayjs/esm/plugin/isoWeek",
-    "cytoscape/dist/cytoscape.umd.js": "cytoscape/dist/cytoscape.esm.js",
-  };
+    {
+      find: "dayjs/plugin/advancedFormat.js",
+      replacement: "dayjs/esm/plugin/advancedFormat"
+    },
+    {
+      find: "dayjs/plugin/customParseFormat.js",
+      replacement: "dayjs/esm/plugin/customParseFormat"
+    },
+    {
+      find: "dayjs/plugin/isoWeek.js",
+      replacement: "dayjs/esm/plugin/isoWeek"
+    },
+    {
+      find: "cytoscape/dist/cytoscape.umd.js",
+      replacement: "cytoscape/dist/cytoscape.esm.js"
+    },
+  ];
 
   return config;
 };


### PR DESCRIPTION
When I write `config.vite.resolve.alias` in `withMermaid`
```js
export default withMermaid({
  vite: {
      resolve: {
        alias: [
          {
            find: /^.*\/VPSwitchAppearance\.vue$/,
            replacement: fileURLToPath(
              new URL('./components/CustomSwitchAppearance.vue', import.meta.url)
            )
          }
        ]
      }
    }
})
```
I've found they don't work. Because what I write will be turned into ☹

```js
"0":{
  find: /^.*\/VPSwitchAppearance\.vue$/,
    replacement: fileURLToPath(
      new URL('./components/CustomSwitchAppearance.vue', import.meta.url)
  )
}
```

So I've tried to fix them

```js
config.vite.resolve.alias = [
    ...config.vite.resolve.alias,
    {
      find: "dayjs/plugin/advancedFormat.js",
      replacement: "dayjs/esm/plugin/advancedFormat"
    },
    {
      find: "dayjs/plugin/customParseFormat.js",
      replacement: "dayjs/esm/plugin/customParseFormat"
    },
    {
      find: "dayjs/plugin/isoWeek.js",
      replacement: "dayjs/esm/plugin/isoWeek"
    },
    {
      find: "cytoscape/dist/cytoscape.umd.js",
      replacement: "cytoscape/dist/cytoscape.esm.js"
    },
  ];
```

But they haven't been tested much by me, so please review them carefully!