### PR TITLE
fix: support users config alias.find with using regexp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ declare module "vitepress" {
 
 export const withMermaid = (config: UserConfig) => {
   if (!config.markdown) config.markdown = {};
-  const markdownConfigOriginal = config.markdown.config || (() => {});
+  const markdownConfigOriginal = config.markdown.config || (() => { });
   config.markdown.config = (...args) => {
     MermaidMarkdown(...args, config.mermaidPlugin);
     markdownConfigOriginal(...args);
@@ -38,27 +38,26 @@ export const withMermaid = (config: UserConfig) => {
     ],
   };
   if (!config.vite.resolve) config.vite.resolve = {};
-  if (!config.vite.resolve.alias) config.vite.resolve.alias = {};
-  const inputAlias = config.vite.resolve.alias;
-  let objAlias = {};
-  if (inputAlias) {
-    // assume that inputAlias conform to vite standard
-    if (Array.isArray(inputAlias) && inputAlias.length !== 0) {
-      inputAlias.forEach(alia => {
-        objAlias[alia.find] = alia.replacement;
-      })
-    } else {
-      objAlias = { ...inputAlias };
-    }
-  }
 
-  config.vite.resolve.alias = {
-    ...objAlias,
+  const mermaidPluginAlias = {
     "dayjs/plugin/advancedFormat.js": "dayjs/esm/plugin/advancedFormat",
     "dayjs/plugin/customParseFormat.js": "dayjs/esm/plugin/customParseFormat",
     "dayjs/plugin/isoWeek.js": "dayjs/esm/plugin/isoWeek",
     "cytoscape/dist/cytoscape.umd.js": "cytoscape/dist/cytoscape.esm.js",
-  };
+  }
+
+  if (!config.vite.resolve.alias) config.vite.resolve.alias = mermaidPluginAlias;
+  else if (Array.isArray(config.vite.resolve.alias)) {
+    config.vite.resolve.alias = [
+      ...config.vite.resolve.alias,
+      ...Object.entries(mermaidPluginAlias).map(([find, replacement]) => ({ find, replacement })),
+    ];
+  } else {
+    config.vite.resolve.alias = {
+      ...config.vite.resolve.alias,
+      ...mermaidPluginAlias,
+    };
+  }
 
   return config;
 };


### PR DESCRIPTION
The `find` property of `alias` may be a `RegExp`, in this case, it cannot be converted to an object and will display an error: `Type 'RegExp' cannot be used as an index type`.

For example, when we need to replace a component of the default theme:

```ts
alias: [
  {
    find: /^.*\/VPHero\.vue$/,
    replacement: fileURLToPath(
      new URL('../theme/components/Hero.vue', import.meta.url),
    ),
  },
]
```