### PR TITLE
fix: production build in vite5

### DIFF
--- a/src/mermaid-plugin.ts
+++ b/src/mermaid-plugin.ts
@@ -11,7 +11,7 @@ interface MermaidPluginOptions extends MermaidConfig {
 
 // Additional configuration for plugin itself. Separate model, not to risk name conflicts with future MermaidConfig options
 export interface MermaidPluginConfig {
-  class?: string;  
+  class?: string;
 }
 
 const DEFAULT_OPTIONS: MermaidConfig = {
@@ -42,10 +42,21 @@ export function MermaidPlugin(
         src =
           "\nimport Mermaid from 'vitepress-plugin-mermaid/Mermaid.vue';\n" +
           src;
-        src = src.replace(
-          "// install global components",
-          "// install global components\n\t\tapp.component('Mermaid', Mermaid);\n"
+
+        const lines = src.split("\n");
+
+        const targetLineIndex = lines.findIndex((line) =>
+          line.includes("app.component")
         );
+
+        lines.splice(
+          targetLineIndex,
+          0,
+          '  app.component("Mermaid", Mermaid);'
+        );
+
+        src = lines.join("\n");
+
         return {
           code: src,
           map: null, // provide source map if available


### PR DESCRIPTION
## Description 
This pull request addresses the issue ["Diagram not Displayed in Production Build"](https://github.com/emersonbottero/vitepress-plugin-mermaid/issues/64), ensuring that diagrams are properly shown in the production environment.

## Cause of the Problem
The root of the problem lies in the [plugin code](https://github.com/emersonbottero/vitepress-plugin-mermaid/blob/4fe352b70704d6668cdd9ce90f0c04569e6bedf4/src/mermaid-plugin.ts#L46-L47). In the production build, the transformation method intended to replace comments and install global components fails to execute correctly. The specific issue is that the targeted comment, which is crucial for the transformation, vanishes before the process can take place.

## Solution Description
I've modified the transformation logic. Now, it does not rely on comments.
