### PR TITLE
fix: set `types` condition to exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "module": "./dist/vitepress-plugin-mermaid.es.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vitepress-plugin-mermaid.es.mjs",
       "require": "./dist/vitepress-plugin-mermaid.umd.js"
     },


### PR DESCRIPTION
Sorry for creating a PR without creating an issue.

I noticed to need to edit package.json to resolve type of `vitepress-plugin-mermaid`.
`types` must be defined in exports field for conditional export environment.

For example, vue/core has a similar definition.
https://github.com/vuejs/core/blob/main/packages/vue/package.json#L22