### PR TITLE
docs: minor documentation updates (yaml highlight, Gantt source code)

### DIFF
--- a/docs/guide/more-examples.md
+++ b/docs/guide/more-examples.md
@@ -7,7 +7,7 @@ title: A more complex example
 
 💡 The theme for each page can be set in the frontmatter mermaidTheme parameter! But is only valid is light mode...
 
-```
+```yaml
 ---
 mermaidTheme: forest
 title: A more complex example

--- a/docs/guide/more-examples.md
+++ b/docs/guide/more-examples.md
@@ -122,6 +122,18 @@ pie title Pets adopted by volunteers
 ```
 ## Gantt
 
+```mmd
+gantt
+    title A Gantt Diagram
+    dateFormat YYYY-MM-DD
+    section Section
+        A task          :a1, 2014-01-01, 30d
+        Another task    :after a1, 20d
+    section Another
+        Task in Another :2014-01-12, 12d
+        another task    :24d
+```
+
 ```mermaid
 gantt
     title A Gantt Diagram


### PR DESCRIPTION
While looking at the documentation I noticed two minor quirks

- Missing yaml highlight for frontmatter example
- Missing source code for the Gantt example

This PR adds both of these.