### PR TITLE
chore: peerDependency vitpress add version ^2.0.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/emersonbottero/vitepress-plugin-mermaid#readme",
   "peerDependencies": {
     "mermaid": "10 || 11",
-    "vitepress": "^1.0.0 || ^1.0.0-alpha"
+    "vitepress": "^1.0.0 || ^1.0.0-alpha || ^2.0.0-alpha"
   },
   "optionalDependencies": {
     "@mermaid-js/mermaid-mindmap": "^9.3.0"


### PR DESCRIPTION
Now, there are ^2.0.0-alpha versions of vitepress. Based on my test vitepress-plugin-mermaid should work properly with it except for the npm install error of the peerDependencies. So I think we can add this new version to the package.json.