### PR TITLE
Chore #88: Add the fullscreen dom at the root level of the body.

### DIFF
--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -8,6 +8,10 @@ export default defineConfig({
         __dirname,
         "../dist/Mermaid.vue"
       ),
+      "vitepress-plugin-mermaid/Mermaid.vue": path.join(
+        __dirname,
+        "../dist/DragMermaid.vue"
+      ),
     },
   },
   server: {

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
         __dirname,
         "../dist/Mermaid.vue"
       ),
-      "vitepress-plugin-mermaid/Mermaid.vue": path.join(
+      "vitepress-plugin-mermaid/DragMermaid.vue": path.join(
         __dirname,
         "../dist/DragMermaid.vue"
       ),

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "import": "./dist/vitepress-plugin-mermaid.es.mjs",
       "require": "./dist/vitepress-plugin-mermaid.umd.js"
     },
-    "./Mermaid.vue": "./dist/Mermaid.vue"
+    "./Mermaid.vue": "./dist/Mermaid.vue",
+    "./DragMermaid.vue": "./dist/DragMermaid.vue"
   },
   "keywords": [
     "vitepress",

--- a/src/DragMermaid.vue
+++ b/src/DragMermaid.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id +'-clone'" ref="diagramContent">
-    <div v-html="svg" class="mermaid-content" :style="contentStyle"></div>
+    <div v-html="svg" class="mermaid-drag-content" :style="contentStyle"></div>
       <button
         class="mermaid-fullscreen-btn"
-        @click="destoryFullscreen"
+        @click="destroyFullscreen"
         title="View in fullscreen"
     >
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M3 21v-5h2v3h3v2zm13 0v-2h3v-3h2v5zM3 8V3h5v2H5v3zm16 0V5h-3V3h5v5z"/></svg>
@@ -87,11 +87,11 @@ const stopDrag = () => {
 };
 const handleKeyDown = (event) => {
   if (event.key === 'Escape') {
-    destoryFullscreen()
+    destroyFullscreen()
   }
 };
 
-const destoryFullscreen = () => {
+const destroyFullscreen = () => {
   const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}-clone"]`);
     
     // Remove fullscreen class from the body.
@@ -155,12 +155,9 @@ onMounted(() => {
 .mermaid-drag-content {
   width: 100%;
   height: 100%;
-   display: flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-}
-.mermaid-content {
-  width: 100%;
 }
 .mermaid-fullscreen-btn {
   position: absolute;

--- a/src/DragMermaid.vue
+++ b/src/DragMermaid.vue
@@ -1,0 +1,240 @@
+<template>
+  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id +'-clone'" ref="diagramContent">
+    <div v-html="svg" class="mermaid-content" :style="contentStyle"></div>
+      <button
+        class="mermaid-fullscreen-btn"
+        @click="destoryFullscreen"
+        title="View in fullscreen"
+    >
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M3 21v-5h2v3h3v2zm13 0v-2h3v-3h2v5zM3 8V3h5v2H5v3zm16 0V5h-3V3h5v5z"/></svg>
+    </button>
+    <div class="mermaid-zoom-controls">
+      <button @click="zoomIn" title="Zoom in">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M8.5 10.5h-1q-.425 0-.712-.288T6.5 9.5t.288-.712T7.5 8.5h1v-1q0-.425.288-.712T9.5 6.5t.713.288t.287.712v1h1q.425 0 .713.288t.287.712t-.288.713t-.712.287h-1v1q0 .425-.288.713T9.5 12.5t-.712-.288T8.5 11.5zm1 5.5q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l5.6 5.6q.275.275.275.7t-.275.7t-.7.275t-.7-.275l-5.6-5.6q-.75.6-1.725.95T9.5 16m0-2q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14"/></svg>
+      </button>
+      <button @click="zoomOut" title="Zoom out">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m19.6 21l-6.3-6.3q-.75.6-1.725.95T9.5 16q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l6.3 6.3zM9.5 14q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14M7 10.5v-2h5v2z"/></svg>
+      </button>
+      <button @click="resetZoom" title="Reset zoom">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m3.9 21.5l-1.4-1.4L5.6 17H3v-2h6v6H7v-2.6zm16.2 0L17 18.4V21h-2v-6h6v2h-2.6l3.1 3.1zM3 9V7h2.6L2.5 3.9l1.4-1.4L7 5.6V3h2v6zm12 0V3h2v2.6l3.1-3.1l1.4 1.4L18.4 7H21v2z"/></svg>
+      </button>
+    </div>
+  </div>
+</template>
+<script setup>
+  import { onMounted, onUnmounted, ref, toRaw, computed, nextTick } from "vue";
+  const props = defineProps({
+    svg: {
+      type: String,
+      required: true,
+      default: null
+    },
+    id: {
+    type: String,
+    required: true,
+  },
+  class:{
+    type: String,
+    required: false,
+    default: "mermaid",
+  },
+
+  });
+  const emits = defineEmits('exitFullScreen')
+  const zoomLevel = ref(1);
+  const position = ref({ x: 0, y: 0 });
+  const diagramContent = ref(null);
+  const isDragging = ref(false);
+  const dragStart = ref({ x: 0, y: 0 });
+
+  const contentStyle = computed(() => ({
+    transform: `scale(${zoomLevel.value}) translate(${position.value.x}px, ${position.value.y}px)`,
+    transformOrigin: 'center center',
+    cursor: isDragging.value ? 'grabbing' : 'grab'
+  }));
+
+  
+const zoomIn = () => {
+  zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x
+};
+const zoomOut = () => {
+  zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x
+};
+const resetZoom = () => {
+  zoomLevel.value = 1;
+  position.value = { x: 0, y: 0 };
+};
+const startDrag = (event) => {
+  isDragging.value = true;
+  dragStart.value = {
+    x: event.clientX - position.value.x,
+    y: event.clientY - position.value.y
+  };
+  document.addEventListener('mousemove', onDrag);
+  document.addEventListener('mouseup', stopDrag);
+};
+const onDrag = (event) => {
+  if (!isDragging.value) return;
+  position.value = {
+    x: event.clientX - dragStart.value.x,
+    y: event.clientY - dragStart.value.y
+  };
+};
+const stopDrag = () => {
+  isDragging.value = false;
+  document.removeEventListener('mousemove', onDrag);
+  document.removeEventListener('mouseup', stopDrag);
+};
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape') {
+    destoryFullscreen()
+  }
+};
+
+const destoryFullscreen = () => {
+  const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}-clone"]`);
+    
+    // Remove fullscreen class from the body.
+    document.body.classList.remove('mermaid-fullscreen-mode');
+    // Remove fullscreen class from this specific container.
+    container.classList.remove('fullscreen');
+    // Reset zoom and position when exiting fullscreen.
+    resetZoom();
+
+    // Remove event listener for ESC key.
+    document.removeEventListener('keydown', handleKeyDown);
+    // Remove event listeners for drag and wheel.
+    if (diagramContent.value) {
+      diagramContent.value.removeEventListener('mousedown', startDrag);
+      diagramContent.value.removeEventListener('wheel', handleWheel);
+    }
+    emits("exitFullScreen");
+}
+const handleWheel = (event) => {
+  // Prevent default scrolling behavior.
+  event.preventDefault();
+  if (event.deltaY < 0) {
+    zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x.
+  } else {
+    zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x.
+  }
+};
+
+
+const initFullscreen = () => {
+    const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}-clone"]`);
+    // Add fullscreen class to the body to handle overflow.
+    document.body.classList.add('mermaid-fullscreen-mode');
+
+    // Add fullscreen class to this specific container.
+    container.classList.add('fullscreen');
+    // Reset zoom and position when entering fullscreen.
+    resetZoom();
+
+    // Add event listener for ESC key.
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Add event listeners for drag start and mouse wheel zoom.
+    if (diagramContent.value) {
+      diagramContent.value.addEventListener('mousedown', startDrag);
+      diagramContent.value.addEventListener('wheel', handleWheel, { passive: false });
+    }
+  
+};
+onMounted(() => {
+  initFullscreen();
+})
+</script>
+<style scoped>
+.mermaid-container {
+  position: fixed;
+  width: 100%;
+  z-index: 9999;
+  left: 0;
+}
+.mermaid-drag-content {
+  width: 100%;
+  height: 100%;
+   display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mermaid-content {
+  width: 100%;
+}
+.mermaid-fullscreen-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background-color: var(--vp-code-copy-code-bg);
+  border: 1px solid var(--vp-code-copy-code-border-color);
+  color: var(--vp-code-copy-code-active-text);
+  border-radius: 4px;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+.mermaid-fullscreen-btn:hover {
+  background-color: var(--vp-code-copy-code-hover-bg);
+  border-color: var(--vp-code-copy-code-hover-border-color);
+}
+body.mermaid-fullscreen-mode {
+  overflow: hidden;
+}
+.mermaid-container.fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(255, 255, 255, 0.95);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+html.dark .mermaid-container.fullscreen {
+  background-color: rgba(30, 30, 30, 0.95);
+}
+.mermaid-container.fullscreen .mermaid-content {
+  max-width: 90%;
+  max-height: 90%;
+  overflow: visible;
+  transition: transform 0.1s ease-out;
+}
+.mermaid-container.fullscreen .mermaid-fullscreen-btn {
+  opacity: 1;
+  top: 16px;
+  right: 16px;
+  bottom: auto;
+}
+.mermaid-zoom-controls {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  gap: 8px;
+  z-index: 10;
+}
+.mermaid-zoom-controls button {
+  background-color: var(--vp-code-copy-code-bg);
+  border: 1px solid var(--vp-code-copy-code-border-color);
+  color: var(--vp-code-copy-code-active-text);
+  border-radius: 4px;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease-in-out;
+}
+.mermaid-zoom-controls button:hover {
+  background-color: var(--vp-code-copy-code-hover-bg);
+  border-color: var(--vp-code-copy-code-hover-border-color);
+}
+</style>

--- a/src/Mermaid.vue
+++ b/src/Mermaid.vue
@@ -133,8 +133,8 @@ const toggleFullscreen = () => {
   isFullscreen.value = !isFullscreen.value;
 
   const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}"]`);
-
   if (isFullscreen.value) {
+
     // Add fullscreen class to the body to handle overflow.
     document.body.classList.add('mermaid-fullscreen-mode');
 
@@ -144,8 +144,11 @@ const toggleFullscreen = () => {
     // Reset zoom and position when entering fullscreen.
     resetZoom();
 
+    // Append dom at body element.
+    document.body.appendChild(container); 
+
     // Add event listener for ESC key.
-    document.addEventListener('keydown', handleKeyDown);
+    container.addEventListener('keydown', handleKeyDown);
 
     // Add event listeners for drag start and mouse wheel zoom.
     if (diagramContent.value) {
@@ -162,8 +165,11 @@ const toggleFullscreen = () => {
     // Reset zoom and position when exiting fullscreen.
     resetZoom();
 
+    // Remove dom from body element.
+    document.body.removeChild(container); 
+
     // Remove event listener for ESC key.
-    document.removeEventListener('keydown', handleKeyDown);
+    container.removeEventListener('keydown', handleKeyDown);
 
     // Remove event listeners for drag and wheel.
     if (diagramContent.value) {

--- a/src/Mermaid.vue
+++ b/src/Mermaid.vue
@@ -1,9 +1,29 @@
 <template>
-  <div v-html="svg" :class="props.class"></div>
+  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id">
+    <div v-html="svg" class="mermaid-content" :style="contentStyle" ref="diagramContent"></div>
+    <button
+        class="mermaid-fullscreen-btn"
+        @click="toggleFullscreen"
+        title="View in fullscreen"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M3 21v-5h2v3h3v2zm13 0v-2h3v-3h2v5zM3 8V3h5v2H5v3zm16 0V5h-3V3h5v5z"/></svg>
+    </button>
+    <div v-if="isFullscreen" class="mermaid-zoom-controls">
+      <button @click="zoomIn" title="Zoom in">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M8.5 10.5h-1q-.425 0-.712-.288T6.5 9.5t.288-.712T7.5 8.5h1v-1q0-.425.288-.712T9.5 6.5t.713.288t.287.712v1h1q.425 0 .713.288t.287.712t-.288.713t-.712.287h-1v1q0 .425-.288.713T9.5 12.5t-.712-.288T8.5 11.5zm1 5.5q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l5.6 5.6q.275.275.275.7t-.275.7t-.7.275t-.7-.275l-5.6-5.6q-.75.6-1.725.95T9.5 16m0-2q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14"/></svg>
+      </button>
+      <button @click="zoomOut" title="Zoom out">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m19.6 21l-6.3-6.3q-.75.6-1.725.95T9.5 16q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l6.3 6.3zM9.5 14q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14M7 10.5v-2h5v2z"/></svg>
+      </button>
+      <button @click="resetZoom" title="Reset zoom">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m3.9 21.5l-1.4-1.4L5.6 17H3v-2h6v6H7v-2.6zm16.2 0L17 18.4V21h-2v-6h6v2h-2.6l3.1 3.1zM3 9V7h2.6L2.5 3.9l1.4-1.4L7 5.6V3h2v6zm12 0V3h2v2.6l3.1-3.1l1.4 1.4L18.4 7H21v2z"/></svg>
+      </button>
+    </div>
+  </div>
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, toRaw } from "vue";
+import { onMounted, onUnmounted, ref, toRaw, computed } from "vue";
 import { render, init } from "./mermaid";
 
 //get mermaid settings
@@ -36,6 +56,122 @@ const props = defineProps({
 
 const svg = ref(null);
 let mut = null;
+const isFullscreen = ref(false);
+const zoomLevel = ref(1);
+const position = ref({ x: 0, y: 0 });
+const diagramContent = ref(null);
+const isDragging = ref(false);
+const dragStart = ref({ x: 0, y: 0 });
+
+const contentStyle = computed(() => ({
+  transform: `scale(${zoomLevel.value}) translate(${position.value.x}px, ${position.value.y}px)`,
+  transformOrigin: 'center center',
+  cursor: isDragging.value ? 'grabbing' : (isFullscreen.value ? 'grab' : 'default')
+}));
+
+const zoomIn = () => {
+  zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x
+};
+
+const zoomOut = () => {
+  zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x
+};
+
+const resetZoom = () => {
+  zoomLevel.value = 1;
+  position.value = { x: 0, y: 0 };
+};
+
+const startDrag = (event) => {
+  if (!isFullscreen.value) return;
+
+  isDragging.value = true;
+  dragStart.value = {
+    x: event.clientX - position.value.x,
+    y: event.clientY - position.value.y
+  };
+
+  document.addEventListener('mousemove', onDrag);
+  document.addEventListener('mouseup', stopDrag);
+};
+
+const onDrag = (event) => {
+  if (!isDragging.value) return;
+
+  position.value = {
+    x: event.clientX - dragStart.value.x,
+    y: event.clientY - dragStart.value.y
+  };
+};
+
+const stopDrag = () => {
+  isDragging.value = false;
+  document.removeEventListener('mousemove', onDrag);
+  document.removeEventListener('mouseup', stopDrag);
+};
+
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape' && isFullscreen.value) {
+    toggleFullscreen();
+  }
+};
+
+const handleWheel = (event) => {
+  if (!isFullscreen.value) return;
+
+  // Prevent default scrolling behavior.
+  event.preventDefault();
+
+  if (event.deltaY < 0) {
+    zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x.
+  } else {
+    zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x.
+  }
+};
+
+const toggleFullscreen = () => {
+  isFullscreen.value = !isFullscreen.value;
+
+  const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}"]`);
+
+  if (isFullscreen.value) {
+    // Add fullscreen class to the body to handle overflow.
+    document.body.classList.add('mermaid-fullscreen-mode');
+
+    // Add fullscreen class to this specific container.
+    container.classList.add('fullscreen');
+
+    // Reset zoom and position when entering fullscreen.
+    resetZoom();
+
+    // Add event listener for ESC key.
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Add event listeners for drag start and mouse wheel zoom.
+    if (diagramContent.value) {
+      diagramContent.value.addEventListener('mousedown', startDrag);
+      diagramContent.value.addEventListener('wheel', handleWheel, { passive: false });
+    }
+  } else {
+    // Remove fullscreen class from the body.
+    document.body.classList.remove('mermaid-fullscreen-mode');
+
+    // Remove fullscreen class from this specific container.
+    container.classList.remove('fullscreen');
+
+    // Reset zoom and position when exiting fullscreen.
+    resetZoom();
+
+    // Remove event listener for ESC key.
+    document.removeEventListener('keydown', handleKeyDown);
+
+    // Remove event listeners for drag and wheel.
+    if (diagramContent.value) {
+      diagramContent.value.removeEventListener('mousedown', startDrag);
+      diagramContent.value.removeEventListener('wheel', handleWheel);
+    }
+  }
+};
 
 onMounted(async () => {
   await init(pluginSettings.value.externalDiagrams);
@@ -95,3 +231,104 @@ const renderChart = async () => {
   svg.value = `${svgCode} <span style="display: none">${salt}</span>`;
 };
 </script>
+
+<style>
+.mermaid-container {
+  position: relative;
+  width: 100%;
+}
+
+.mermaid-content {
+  width: 100%;
+}
+
+.mermaid-fullscreen-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background-color: var(--vp-code-copy-code-bg);
+  border: 1px solid var(--vp-code-copy-code-border-color);
+  color: var(--vp-code-copy-code-active-text);
+  border-radius: 4px;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.mermaid-fullscreen-btn:hover {
+  background-color: var(--vp-code-copy-code-hover-bg);
+  border-color: var(--vp-code-copy-code-hover-border-color);
+}
+
+body.mermaid-fullscreen-mode {
+  overflow: hidden;
+}
+
+.mermaid-container {
+  position: relative;
+  width: 100%;
+}
+
+.mermaid-container.fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(255, 255, 255, 0.95);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+html.dark .mermaid-container.fullscreen {
+  background-color: rgba(30, 30, 30, 0.95);
+}
+
+.mermaid-container.fullscreen .mermaid-content {
+  max-width: 90%;
+  max-height: 90%;
+  overflow: visible;
+  transition: transform 0.1s ease-out;
+}
+
+.mermaid-container.fullscreen .mermaid-fullscreen-btn {
+  opacity: 1;
+  top: 16px;
+  right: 16px;
+  bottom: auto;
+}
+
+.mermaid-zoom-controls {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  gap: 8px;
+  z-index: 10;
+}
+
+.mermaid-zoom-controls button {
+  background-color: var(--vp-code-copy-code-bg);
+  border: 1px solid var(--vp-code-copy-code-border-color);
+  color: var(--vp-code-copy-code-active-text);
+  border-radius: 4px;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.mermaid-zoom-controls button:hover {
+  background-color: var(--vp-code-copy-code-hover-bg);
+  border-color: var(--vp-code-copy-code-hover-border-color);
+}
+</style>

--- a/src/Mermaid.vue
+++ b/src/Mermaid.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id">
-    <div v-html="svg" class="mermaid-content" :style="contentStyle" ref="diagramContent"></div>
+  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id" ref="diagramContent">
+    <div v-html="svg" class="mermaid-content" :style="contentStyle"></div>
     <button
         class="mermaid-fullscreen-btn"
         @click="toggleFullscreen"

--- a/src/Mermaid.vue
+++ b/src/Mermaid.vue
@@ -1,29 +1,22 @@
 <template>
-  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id" ref="diagramContent">
-    <div v-html="svg" class="mermaid-content" :style="contentStyle"></div>
-    <button
+  <div class="mermaid-container" :class="props.class" :data-mermaid-id="props.id">
+    <div v-html="svg" class="mermaid-content"></div>
+      <button
         class="mermaid-fullscreen-btn"
         @click="toggleFullscreen"
         title="View in fullscreen"
-    >
+      >
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M3 21v-5h2v3h3v2zm13 0v-2h3v-3h2v5zM3 8V3h5v2H5v3zm16 0V5h-3V3h5v5z"/></svg>
     </button>
-    <div v-if="isFullscreen" class="mermaid-zoom-controls">
-      <button @click="zoomIn" title="Zoom in">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M8.5 10.5h-1q-.425 0-.712-.288T6.5 9.5t.288-.712T7.5 8.5h1v-1q0-.425.288-.712T9.5 6.5t.713.288t.287.712v1h1q.425 0 .713.288t.287.712t-.288.713t-.712.287h-1v1q0 .425-.288.713T9.5 12.5t-.712-.288T8.5 11.5zm1 5.5q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l5.6 5.6q.275.275.275.7t-.275.7t-.7.275t-.7-.275l-5.6-5.6q-.75.6-1.725.95T9.5 16m0-2q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14"/></svg>
-      </button>
-      <button @click="zoomOut" title="Zoom out">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m19.6 21l-6.3-6.3q-.75.6-1.725.95T9.5 16q-2.725 0-4.612-1.888T3 9.5t1.888-4.612T9.5 3t4.613 1.888T16 9.5q0 1.1-.35 2.075T14.7 13.3l6.3 6.3zM9.5 14q1.875 0 3.188-1.312T14 9.5t-1.312-3.187T9.5 5T6.313 6.313T5 9.5t1.313 3.188T9.5 14M7 10.5v-2h5v2z"/></svg>
-      </button>
-      <button @click="resetZoom" title="Reset zoom">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m3.9 21.5l-1.4-1.4L5.6 17H3v-2h6v6H7v-2.6zm16.2 0L17 18.4V21h-2v-6h6v2h-2.6l3.1 3.1zM3 9V7h2.6L2.5 3.9l1.4-1.4L7 5.6V3h2v6zm12 0V3h2v2.6l3.1-3.1l1.4 1.4L18.4 7H21v2z"/></svg>
-      </button>
-    </div>
   </div>
+  <Teleport to="body" :disabled="!isFullscreen">
+    <DragMermaid :svg="svg" :id="props.id" :class="props.class" v-if="isFullscreen" @exitFullScreen="exitFullScreen"></DragMermaid>
+  </Teleport>
 </template>
 
 <script setup>
 import { onMounted, onUnmounted, ref, toRaw, computed } from "vue";
+import DragMermaid  from './DragMermaid.vue'
 import { render, init } from "./mermaid";
 
 //get mermaid settings
@@ -57,128 +50,14 @@ const props = defineProps({
 const svg = ref(null);
 let mut = null;
 const isFullscreen = ref(false);
-const zoomLevel = ref(1);
-const position = ref({ x: 0, y: 0 });
-const diagramContent = ref(null);
-const isDragging = ref(false);
-const dragStart = ref({ x: 0, y: 0 });
-
-const contentStyle = computed(() => ({
-  transform: `scale(${zoomLevel.value}) translate(${position.value.x}px, ${position.value.y}px)`,
-  transformOrigin: 'center center',
-  cursor: isDragging.value ? 'grabbing' : (isFullscreen.value ? 'grab' : 'default')
-}));
-
-const zoomIn = () => {
-  zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x
-};
-
-const zoomOut = () => {
-  zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x
-};
-
-const resetZoom = () => {
-  zoomLevel.value = 1;
-  position.value = { x: 0, y: 0 };
-};
-
-const startDrag = (event) => {
-  if (!isFullscreen.value) return;
-
-  isDragging.value = true;
-  dragStart.value = {
-    x: event.clientX - position.value.x,
-    y: event.clientY - position.value.y
-  };
-
-  document.addEventListener('mousemove', onDrag);
-  document.addEventListener('mouseup', stopDrag);
-};
-
-const onDrag = (event) => {
-  if (!isDragging.value) return;
-
-  position.value = {
-    x: event.clientX - dragStart.value.x,
-    y: event.clientY - dragStart.value.y
-  };
-};
-
-const stopDrag = () => {
-  isDragging.value = false;
-  document.removeEventListener('mousemove', onDrag);
-  document.removeEventListener('mouseup', stopDrag);
-};
-
-const handleKeyDown = (event) => {
-  if (event.key === 'Escape' && isFullscreen.value) {
-    toggleFullscreen();
-  }
-};
-
-const handleWheel = (event) => {
-  if (!isFullscreen.value) return;
-
-  // Prevent default scrolling behavior.
-  event.preventDefault();
-
-  if (event.deltaY < 0) {
-    zoomLevel.value = Math.min(zoomLevel.value + 0.1, 3); // Max zoom 3x.
-  } else {
-    zoomLevel.value = Math.max(zoomLevel.value - 0.1, 0.5); // Min zoom 0.5x.
-  }
-};
 
 const toggleFullscreen = () => {
   isFullscreen.value = !isFullscreen.value;
-
-  const container = document.querySelector(`.mermaid-container[data-mermaid-id="${props.id}"]`);
-  if (isFullscreen.value) {
-
-    // Add fullscreen class to the body to handle overflow.
-    document.body.classList.add('mermaid-fullscreen-mode');
-
-    // Add fullscreen class to this specific container.
-    container.classList.add('fullscreen');
-
-    // Reset zoom and position when entering fullscreen.
-    resetZoom();
-
-    // Append dom at body element.
-    document.body.appendChild(container); 
-
-    // Add event listener for ESC key.
-    container.addEventListener('keydown', handleKeyDown);
-
-    // Add event listeners for drag start and mouse wheel zoom.
-    if (diagramContent.value) {
-      diagramContent.value.addEventListener('mousedown', startDrag);
-      diagramContent.value.addEventListener('wheel', handleWheel, { passive: false });
-    }
-  } else {
-    // Remove fullscreen class from the body.
-    document.body.classList.remove('mermaid-fullscreen-mode');
-
-    // Remove fullscreen class from this specific container.
-    container.classList.remove('fullscreen');
-
-    // Reset zoom and position when exiting fullscreen.
-    resetZoom();
-
-    // Remove dom from body element.
-    document.body.removeChild(container); 
-
-    // Remove event listener for ESC key.
-    container.removeEventListener('keydown', handleKeyDown);
-
-    // Remove event listeners for drag and wheel.
-    if (diagramContent.value) {
-      diagramContent.value.removeEventListener('mousedown', startDrag);
-      diagramContent.value.removeEventListener('wheel', handleWheel);
-    }
-  }
 };
 
+const exitFullScreen = () => {
+  isFullscreen.value = false
+}
 onMounted(async () => {
   await init(pluginSettings.value.externalDiagrams);
   let settings = await import("virtual:mermaid-config");
@@ -237,17 +116,17 @@ const renderChart = async () => {
   svg.value = `${svgCode} <span style="display: none">${salt}</span>`;
 };
 </script>
-
-<style>
+<style scoped>
+.mermaid-container {
+  position: fixed;
+  width: 100%;
+  z-index: 9999;
+  left: 0;
+}
 .mermaid-container {
   position: relative;
   width: 100%;
 }
-
-.mermaid-content {
-  width: 100%;
-}
-
 .mermaid-fullscreen-btn {
   position: absolute;
   bottom: 8px;
@@ -263,77 +142,7 @@ const renderChart = async () => {
   justify-content: center;
   z-index: 10;
 }
-
 .mermaid-fullscreen-btn:hover {
-  background-color: var(--vp-code-copy-code-hover-bg);
-  border-color: var(--vp-code-copy-code-hover-border-color);
-}
-
-body.mermaid-fullscreen-mode {
-  overflow: hidden;
-}
-
-.mermaid-container {
-  position: relative;
-  width: 100%;
-}
-
-.mermaid-container.fullscreen {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(255, 255, 255, 0.95);
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-  box-sizing: border-box;
-}
-
-html.dark .mermaid-container.fullscreen {
-  background-color: rgba(30, 30, 30, 0.95);
-}
-
-.mermaid-container.fullscreen .mermaid-content {
-  max-width: 90%;
-  max-height: 90%;
-  overflow: visible;
-  transition: transform 0.1s ease-out;
-}
-
-.mermaid-container.fullscreen .mermaid-fullscreen-btn {
-  opacity: 1;
-  top: 16px;
-  right: 16px;
-  bottom: auto;
-}
-
-.mermaid-zoom-controls {
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-  display: flex;
-  gap: 8px;
-  z-index: 10;
-}
-
-.mermaid-zoom-controls button {
-  background-color: var(--vp-code-copy-code-bg);
-  border: 1px solid var(--vp-code-copy-code-border-color);
-  color: var(--vp-code-copy-code-active-text);
-  border-radius: 4px;
-  padding: 4px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.mermaid-zoom-controls button:hover {
   background-color: var(--vp-code-copy-code-hover-bg);
   border-color: var(--vp-code-copy-code-hover-border-color);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
           src: "src/Mermaid.vue",
           dest: "./",
         },
+         {
+          src: "src/DragMermaid.vue",
+          dest: "./",
+        },
         {
           src: "src/mermaid.ts",
           dest: "./",


### PR DESCRIPTION
## 🔗 Related
Supersedes #88 

## 🎯 Why
Sometimes we do not use the original theme of vitepress or configure the page layout ourselves, which leads to a bug where the full-screen dom is wrongly positioned when opened under the current element. This PR elevates the full-screen dom to the first level of the body tag.

## ✨ Optimized

- [ x ] Add fullscreen dom at the root level of the body.
- [ x ] Changes to drag and zoom are available throughout the full screen dom.
- [ x ] Use Teleport to add the full-screen function to the root of the body and componentize it.